### PR TITLE
Some tidy-ups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,5 @@
 # Then get your OpenAI API Key here: https://platform.openai.com/account/api-keys
 OPENAI_API_KEY=XXXXXXXX
 
-
+# Generate a Humanloop API Key here: https://app.humanloop.com/account/api-keys
+HUMANLOOP_API_KEY=XXXXXXXX

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -6,10 +6,6 @@ export const runtime = 'edge'
 
 const HUMANLOOP_API_KEY = process.env.HUMANLOOP_API_KEY
 
-if (!HUMANLOOP_API_KEY) {
-  throw new Error('HUMANLOOP_API_KEY is not set')
-}
-
 const humanloop = new Humanloop({
   useFetch: true, // useFetch must be "true" for humanloop to work in Next.js edge runtime,
   openaiApiKey: process.env.OPENAI_API_KEY,
@@ -17,6 +13,10 @@ const humanloop = new Humanloop({
 })
 
 export async function POST(req: Request) {
+  if (!HUMANLOOP_API_KEY) {
+    throw new Error('HUMANLOOP_API_KEY is not set')
+  }
+
   const { messages } = await req.json()
 
   const chatResponse = await humanloop.chatStream({

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,10 +5,8 @@ import { Toaster } from 'react-hot-toast'
 import '@/app/globals.css'
 import { fontMono, fontSans } from '@/lib/fonts'
 import { cn } from '@/lib/utils'
-import { TailwindIndicator } from '@/components/tailwind-indicator'
 import { Providers } from '@/components/providers'
 import { Header } from '@/components/header'
-import { ThemeToggle } from '@/components/theme-toggle'
 
 export const metadata: Metadata = {
   title: {

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -22,7 +22,7 @@ export function Chat({ id, initialMessages, className }: ChatProps) {
       id,
       body: { id },
       onResponse(response) {
-        if (response.status === 401) {
+        if (response.status !== 200) {
           toast.error(response.statusText)
         }
       }

--- a/lib/humanloop-stream.ts
+++ b/lib/humanloop-stream.ts
@@ -1,30 +1,36 @@
 /**
  * Converts the Humanloop stream to a stream of just text
- * 
+ *
  * (This is only necessary to make this work nicely with the ai package's useChat hook)
- * 
- * @param input a stream of Humanloop responses { output: string, id: string}
+ *
+ * @param input a stream of Humanloop responses { output: string, id: string }
  * @returns a stream of just text
  */
 export function HumanloopStream(input: ReadableStream): ReadableStream {
-    const reader = input.getReader()
-    const encoder = new TextEncoder()
-  
-    return new ReadableStream({
-      async pull(controller) {
-        const { value, done } = await reader.read()
-        if (done) {
-          controller.close()
-          return
-        }
-        const decoded = new TextDecoder().decode(value)
-        const chunks = decoded
-          .split('}')
-          .filter(Boolean)
-          .map(chunk => JSON.parse(chunk + '}'))
-  
-        chunks.forEach(chunk => controller.enqueue(encoder.encode(chunk.output)))
+  const reader = input.getReader()
+  const encoder = new TextEncoder()
+
+  let tmp: string = ''
+
+  return new ReadableStream({
+    async pull(controller) {
+      const { value, done } = await reader.read()
+      if (done) {
+        controller.close()
+        return
       }
-    })
-  }
-  
+      const decoded = new TextDecoder().decode(value)
+      const chunks = decoded.split('}').filter(Boolean)
+
+      for (let chunk of chunks) {
+        try {
+          const parsed = JSON.parse(tmp + chunk + '}')
+          tmp = ''
+          controller.enqueue(encoder.encode(parsed.output))
+        } catch (e) {
+          tmp += chunk + '}'
+        }
+      }
+    }
+  })
+}


### PR DESCRIPTION
A couple of small tweaks:

- I found that there was no visual warning that something was wrong on screen if you haven't set up a Humanloop API key in `.env` (you have to be looking carefully at the server-side console to get that). Have made it so a toast pops up if you don't have the key set
- Have also added `HUMANLOOP_API_KEY` to .env.example, otherwise no one will know to add it..!
- Modified the streaming logic, because it wasn't robust to any output that contains a '}' in it. 

Question for @jordn: we still have an API route here for `/api/openai-chat`. Is this deliberately left in to demonstrate how one would convert from it to a Humanloop version? The route isn't actually called from anywhere.

Separately, I thought it might be nice to include a button on screen that let's the user click through the Humanloop project where all the outputs are being logged. This might help newcomers quickly grok that Humanloop is capturing everything from their production app. But it's actually not super easy to implement because we need the project id, and don't have it anywhere. So probably won't pursue this unless you think very worthwhile.

As discussed last week, I think having a single 'examples' repo is a nice idea, so propose I move this into such a repo and then also move `asap` and `coworker` into there too.